### PR TITLE
Fixing errors - UNKNOWN: Unable to parse arguments: "Namespace" object h...

### DIFF
--- a/puppetagent.py
+++ b/puppetagent.py
@@ -54,9 +54,9 @@ def time_prettyfy(secs):
 
 def optionsparser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-w", "--warn", dest="warning", type=int, default=1200,
+    parser.add_argument("-w", "--warn", dest="warn", type=int, default=1200,
                         help="seconds after last Puppet run which issues a warning")
-    parser.add_argument("-c", "--crit", type=int, dest="critical", default=2700,
+    parser.add_argument("-c", "--crit", type=int, dest="crit", default=2700,
                         help="seconds after last Puppet run which are critical")
     arguments = parser.parse_args()
 


### PR DESCRIPTION
These errors are presented when running this plugin inside the portal:

return code: 3
UNKNOWN: Unable to parse arguments: 'Namespace' object has no attribute 'warn'

I believe this to be a consequence of line 64 and 65 not having initialised namespaces.  Lines 57 and 59 reference 'warning' and 'critical', whilst 64 and 65 require them to be 'warn' and 'crit'.
