### PR TITLE
Including more metrics exposed by RDS

### DIFF
--- a/cloudwatch.rds.py
+++ b/cloudwatch.rds.py
@@ -14,6 +14,8 @@ RDS_INSTANCE_ID = ''
 ### Real code
 metrics = {"BinLogDiskUsage": {"type":"float", "value":None, "uom":"B"},
            "CPUUtilization":{"type":"float", "value":None, "uom":"%"},
+           "CPUCreditUsage":{"type":"float", "value":None, "uom":""},
+           "CPUCreditBalance":{"type":"float", "value":None, "uom":""},
            "DatabaseConnections":{"type":"int", "value":None, "uom":""},
            "DiskQueueDepth":{"type":"int", "value":None, "uom":""},
            "FreeableMemory":{"type":"float", "value":None, "uom":"GB"},


### PR DESCRIPTION
We use t2 instances for our staging and development environments, they expose additional credit related metrics.
